### PR TITLE
Fix memory leak when positioning player

### DIFF
--- a/src/Game.bf
+++ b/src/Game.bf
@@ -20,8 +20,8 @@ class Game
 		Data.player = new Player(new KeyboardPlayerInput());
 		Data.entities.Add(Data.player);
 
-		//center the player
-		Data.player.position = *(new Vector2(GetScreenWidth() / 2, GetScreenHeight() / 2));
+               //center the player without allocating on the heap
+               Data.player.position = Vector2((float)GetScreenWidth() / 2, (float)GetScreenHeight() / 2);
 
 
 


### PR DESCRIPTION
## Summary
- avoid heap allocation when centering the player

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683fc693a15c8324a79e431d23290f96